### PR TITLE
Fix new build to use ACMEv2 by default

### DIFF
--- a/githubx/client.go
+++ b/githubx/client.go
@@ -83,7 +83,7 @@ func NewAppClient(privateKey string, appID, installationID int64) *github.Client
 	// authenticates using the given private key for the given app and installation
 	// IDs.
 	itr, err := ghinstallation.NewKeyFromFile(
-		http.DefaultTransport, (int)(appID), (int)(installationID), privateKey)
+		http.DefaultTransport, appID, installationID, privateKey)
 	if err != nil {
 		log.Println(err)
 		return nil

--- a/k8s/github-webhook-receiver.yml
+++ b/k8s/github-webhook-receiver.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: github-webhook-receiver
-        image: soltesz/github-webhook-receiver:v0.0.8
+        image: soltesz/github-webhook-receiver:v0.0.9
         env:
         - name: WEBHOOK_HOSTNAME
           value: webhook-receiver.mlab-sandbox.measurementlab.net


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stephen-soltesz/github-webhook-receiver/3)
<!-- Reviewable:end -->
